### PR TITLE
Update Frameworktest to be a vendormodule and tweaks

### DIFF
--- a/code/Company.php
+++ b/code/Company.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\FrameworkTest\Model;
 
+use SilverStripe\Forms\DropdownField;
 use SilverStripe\ORM\ValidationResult;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
@@ -337,5 +338,10 @@ class Company extends DataObject
             214 => array("Ahold", "Retailing", "40.229", "Dick Boer"),
             215 => array("Cisco", "Information technology", "40.04", "John T. Chambers"),
         );
+    }
+
+    public function scaffoldSearchField()
+    {
+        return DropdownField::create('CompanyID', 'Company', self::get()->map())->setEmptyString('');
     }
 }

--- a/code/TestPage.php
+++ b/code/TestPage.php
@@ -4,6 +4,8 @@ namespace SilverStripe\FrameworkTest\Model;
 
 use Page;
 use PageController;
+use SilverStripe\Core\Manifest\ModuleResource;
+use SilverStripe\Core\Manifest\ModuleResourceLoader;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Forms\FormAction;
@@ -87,7 +89,10 @@ class TestPage_Controller extends PageController
             new FormAction("save", "Save"),
             $gohome = new FormAction("gohome", "Go home")
         );
-        $gohome->setAttribute('src', 'frameworktest/images/test-button.png');
+        $gohome->setAttribute(
+            'src',
+            ModuleResourceLoader::resourceURL('silverstripe/frameworktest: images/test-button.png')
+        );
         $form = new Form($this, "Form", $fields, $actions);
         $form->loadDataFrom($this->dataRecord);
         return $form;

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "expose": [
             "client/dist",
             "css",
-
+            "images"
         ]
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "silverstripe/frameworktest",
 	"description": "Aids core and module developers in testing their code against a set of sample data and behaviour.",
-	"type": "silverstripe-module",
+    "type": "silverstripe-vendormodule",
 	"keywords": ["silverstripe", "frameworktest", "testing"],
 	"license": "BSD-3-Clause",
 	"authors": [
@@ -15,6 +15,19 @@
 		"silverstripe/framework": "~4.0",
 		"silverstripe/cms": "~4.0",
 		"guzzlehttp/guzzle": "~6.0",
-		"fzaninotto/faker": "^1.7"
-	}
+		"fzaninotto/faker": "^1.7",
+        "silverstripe/vendor-plugin": "^1.0"
+	},
+    "extra": {
+        "expose": [
+            "client/dist",
+            "css",
+
+        ]
+    },
+    "autoload": {
+        "psr-4": {
+            "SSilverStripe\\FrameworkTest\\": "code/"
+        }
+    }
 }


### PR DESCRIPTION
This PR does the following things:
* Update the module to be a vendormodule (this seems to have fixed the Test React Form Builder ... at least partially)
* Update Employee with:
  * an auto populated date of birth
  * an auto populated category enum
  * fulltext search index on Name and Biography
  * auto assign employees to companies
  * auto create biographies from random list of words
  * add search fields for
    * Name (simple use case)
    * Company Name starting with (remote has-one relation )
    * Company ID less than (less than filter)
    * Company colleagues names (remote has-many relation )
    * Date of birth (Datefield)
    * Category (DropdownField)
    * Full text search

This is mostly aimed at testing https://github.com/silverstripe/silverstripe-admin/pull/687, but it can provide longer term benefits.
