### PR TITLE
Require silverstripe/registry

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
 		"silverstripe/cms": "~4.0",
 		"guzzlehttp/guzzle": "~6.0",
 		"fzaninotto/faker": "^1.7",
-        "silverstripe/vendor-plugin": "^1.0"
+        "silverstripe/vendor-plugin": "^1.0",
+		"silverstripe/registry": "~2"
 	},
     "extra": {
         "expose": [


### PR DESCRIPTION
Those class_exists() check don't work with class manifests.
Check the logic in ClassManifestVisitor - it just parses PHP until it finds
class definitions. Which means you'll have those files in the manifest,
but when dev/build tries to instantiate them it fails
with an InjectorNotFoundException.

We could argue that this should be fixed in core,
but I'm not sure that this style of conditional classes
needs to be supported.