### PR TITLE
NEW Generate blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,30 @@ If you want to test the CMS behaviour for a large and nested tree,
 the module includes a simple generator task: `dev/tasks/FTPageMakerTask`.
 It will create 3^5 pages by default, so takes a while to run through.
 
+## Blocks
+
+When [dnadesign/silverstripe-elemental](https://github.com/dnadesign/silverstripe-elemental)
+is installed, the `FTPageMakerTask` can also generate blocks within those pages automatically.
+It has a few hardcoded sample data structures for common block types,
+and randomly creates a number of blocks, as well as randomly choosing to publish them.
+Relies on files and images being available to add as sample data. 
+
+Additional setup:
+
+```
+composer require dnadesign/silverstripe-elemental
+composer require silverstripe/elemental-bannerblock
+composer require silverstripe/elemental-fileblock
+```
+
+Usage:
+
+```
+# Generate some sample files to associate with blocks
+sake dev/tasks/FTFileMakerTask
+sake dev/tasks/FTPageMakerTask withBlocks=true
+```
+
 ## Requirements
 
 The module is intended to run against the latest core codebase,

--- a/_config/elemental.yml
+++ b/_config/elemental.yml
@@ -1,0 +1,7 @@
+---
+Only:
+  classexists: 'DNADesign\Elemental\Extensions\ElementalPageExtension'
+---
+SilverStripe\FrameworkTest\Model\TestPage:
+  extensions:
+    - DNADesign\Elemental\Extensions\ElementalPageExtension

--- a/code/TestPage.php
+++ b/code/TestPage.php
@@ -20,7 +20,7 @@ use SilverStripe\Security\Security;
 /**
  * Parent class of all test pages
  */
-class TestPage extends Page
+class TestPage extends Page implements \TestPageInterface
 {
     private static $table_name = 'FrameworkTestPage';
 

--- a/code/tasks/FTPageMakerTask.php
+++ b/code/tasks/FTPageMakerTask.php
@@ -1,17 +1,24 @@
 <?php
 
+use DNADesign\Elemental\Models\ElementContent;
+use SilverStripe\Assets\File;
+use SilverStripe\Assets\Image;
 use SilverStripe\Dev\BuildTask;
 use SilverStripe\Core\ClassInfo;
+use DNADesign\Elemental\Models\BaseElement;
+use SilverStripe\ElementalBannerBlock\Block\BannerBlock;
+use SilverStripe\ElementalFileBlock\Block\FileBlock;
+
 
 /**
  * Creates sample page structure, useful to test tree performance,
  * UI behaviour on deeply nested pages etc.
- * 
+ *
  * @todo Allow passing in counts
  */
 class FTPageMakerTask extends BuildTask
 {
-    
+
     /**
      * Defaults create 2,000 pages
      */
@@ -20,20 +27,43 @@ class FTPageMakerTask extends BuildTask
         100,
         1,
         1,
-        1
+    ];
+
+    /**
+     * @var array Range of blocks to add (in case elemental is installed).
+     * Will create between X and Y blocks randomly.
+     */
+    protected $blockCountRange = [
+        1,
+        10
+    ];
+
+    /**
+     * @var array
+     * @config
+     */
+    private static $block_generators = [
+        'DNADesign\Elemental\Models\ElementContent' => [self::class, 'generateContentBlock'],
+        'SilverStripe\ElementalBannerBlock\Block\BannerBlock' => [self::class, 'generateBannerBlock'],
+        'SilverStripe\ElementalFileBlock\Block\FileBlock' => [self::class, 'generateFileBlock'],
     ];
 
     public function run($request)
     {
-        $this->generatePages();
+        // Optionally add blocks
+        $withBlocks = (bool)$request->getVar('withBlocks');
+        if ($withBlocks && !class_exists('DNADesign\Elemental\Models\BaseElement')) {
+            throw new \LogicException('withBlocks requested, but BaseElement class not found');
+        }
+
+        $this->generatePages(0, "", 0, $withBlocks);
     }
 
-    protected function generatePages($depth = 0, $prefix = "", $parentID = 0)
+    protected function generatePages($depth = 0, $prefix = "", $parentID = 0, $withBlocks = false)
     {
         $maxDepth = count($this->pageCountByDepth);
         $pageCount = $this->pageCountByDepth[$depth];
         $testPageClasses = ClassInfo::implementorsOf('TestPageInterface');
-        $testPageClasses[] = 'Page';
 
         for ($i=1; $i<=$pageCount; $i++) {
             $fullPrefix = $prefix ? "{$prefix}-{$i}" : $i;
@@ -46,14 +76,80 @@ class FTPageMakerTask extends BuildTask
             $page->publish('Stage', 'Live');
 
             echo "Created '$page->Title' ($page->ClassName)\n";
-            
+
+            if ($withBlocks) {
+                $this->generateBlocksForPage($page);
+            }
+
             $pageID = $page->ID;
+
             unset($page);
 
             if ($depth < $maxDepth-1) {
-                $this->generatePages($depth+1, $fullPrefix, $pageID);
+                $this->generatePages($depth+1, $fullPrefix, $pageID, $withBlocks);
             }
         }
     }
-    
+
+    protected function generateBlocksForPage(Page $page)
+    {
+        $classes = array_filter($this->config()->get('block_generators'), function ($callable, $class) {
+            return class_exists($class);
+        }, ARRAY_FILTER_USE_BOTH);
+
+        // Generate a random amount of blocks in the preferred range
+        $range = $this->blockCountRange;
+        foreach(range($range[0], array_rand(range($range[0], $range[1]))) as $i) {
+            $class = array_rand($classes);
+            $callable = $classes[$class];
+            $block = call_user_func($callable);
+
+            // Add block to page
+            $page->ElementalArea()->Elements()->add($block);
+
+            // 50% chance of block being published
+            if (rand(0,1) === 0) {
+                $block->publishRecursive();
+            }
+
+            echo sprintf("  Added '%s' block #%d to page #%d\n", $class, $block->ID, $page->ID);
+        }
+    }
+
+    public static function generateContentBlock()
+    {
+        $block = new ElementContent([
+            'HTML' => '<bold>test</bold> 123'
+        ]);
+        $block->write();
+
+        return $block;
+    }
+
+    public static function generateFileBlock()
+    {
+        // Supports both images and files
+        $file = File::get()->shuffle()->First();
+        if (!$file) {
+            throw new \LogicException('No files found to associate with FileBlock');
+        }
+
+        $block = new FileBlock();
+        $block->FileID = $file->ID;
+        $block->write();
+
+        return $block;
+    }
+
+    public static function generateBannerBlock()
+    {
+        $block = new BannerBlock([
+            'Content' => '<bold>test</bold> 123',
+            'CallToActionLink' => 'http://example.com',
+        ]);
+        $block->write();
+
+        return $block;
+    }
+
 }


### PR DESCRIPTION
It's not a masterpiece of modular architecture, but it does the job ;)

There's two use cases I've built this for:
1. Test Aaron's pull requests around GraphQL v3 and v4 backwards compat in elemental
2. Create arbitrarily complex websites to test somewhat realistic decoupled publishing
through NextJS and Gatsby without relying on customer data (or being restricted to their content structure/volume)